### PR TITLE
Update Base Docker Image to Python 3.12

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6.0.0
         with:
-          python-version: '3.10'
+          python-version: '3.12'
           cache: pip
 
       - name: Install pre-commit and pip-tools

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6.0.0
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-FROM python:3.12-alpine AS base
-
-# Install AWS Lambda Runtime Interface Client
-RUN pip3 install awslambdaric
+FROM public.ecr.aws/lambda/python:3.12 AS base
 
 # Install Python requirements
 COPY requirements.txt .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.10
+FROM public.ecr.aws/lambda/python:3.12
 
 # Copy function code
 COPY create_message.py ${LAMBDA_TASK_ROOT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.12 AS base
+FROM public.ecr.aws/lambda/python:3.12
 
 # Install Python requirements
 COPY requirements.txt .
@@ -8,5 +8,4 @@ RUN  pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
 COPY create_message.py ${LAMBDA_TASK_ROOT}
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
-FROM base AS build
 CMD [ "create_message.main" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
-FROM public.ecr.aws/lambda/python:3.12
+FROM python:3.12-alpine AS base
 
-# Copy function code
-COPY create_message.py ${LAMBDA_TASK_ROOT}
+# Install AWS Lambda Runtime Interface Client
+RUN pip3 install awslambdaric
 
-# Install the function's dependencies using file requirements.txt
-# from your project folder.
-
-COPY requirements.txt  .
+# Install Python requirements
+COPY requirements.txt .
 RUN  pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
 
+# Add code
+COPY create_message.py ${LAMBDA_TASK_ROOT}
+
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+FROM base AS build
 CMD [ "create_message.main" ]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Post a list of newly published archival collections to a Microsoft Teams channel.
 
 ## Dependencies
-- Python 3 (tested on 3.9)
+- Python 3
 - [ArchivesSnake](https://pypi.org/project/boto3/)
 - [boto3](https://pypi.org/project/ArchivesSnake/)
 - [requests](https://pypi.org/project/requests/)


### PR DESCRIPTION
Updates to Python 3.12

Note: considered using Alpine base Docker image instead of the AWS base image, which [requires adding the Lambda Runtime Interface Client](https://docs.aws.amazon.com/lambda/latest/dg/python-image.html#python-image-clients) installation to the Dockerfile, but in consultation with IT decided to stick with the official aws base image.